### PR TITLE
fix link to Nonlinear operators in SOCP tutorial

### DIFF
--- a/_posts/tutorials/2016-09-17-socpprogramming.md
+++ b/_posts/tutorials/2016-09-17-socpprogramming.md
@@ -34,7 +34,7 @@ F = [cone(y-A*xhat,u), cone(xhat,v)];
 optimize(F,u + v);
 ````
 
-By using the automatic modelling support in the [nonlinear operator framework](/tutorial/nonlinearoperator), we can alternatively write it in the following epigraph form
+By using the automatic modelling support in the [nonlinear operator framework](/tutorial/nonlinearoperators), we can alternatively write it in the following epigraph form
 
 ````matlab
 xhat = sdpvar(6,1);


### PR DESCRIPTION
Dear YALMIP maintainer, I just spotted on broken link in the SOCP tutorial. I fixed (hopefully!) the typo in the URL.