### PR TITLE
fix typo in 2021-05-05-integratedpwa.md

### DIFF
--- a/_posts/examples/2021-05-05-integratedpwa.md
+++ b/_posts/examples/2021-05-05-integratedpwa.md
@@ -96,7 +96,7 @@ In this form, we have an MIQP, possibly with nonconvex objective, meaning we are
 
 ### Getting lazy
 
-The reaon we use YALMIP is because we are lazy, so the models above are too much manual labour. Our goal is to do all the integration related manipulations automatically.
+The reason we use YALMIP is because we are lazy, so the models above are too much manual labour. Our goal is to do all the integration related manipulations automatically.
 
 First, note that the integral is \\( \int_0^x f(z)dz  = \int_0^{u_1} f_1(z)dz + \int_{u_1}^{u_2} f_2(z)dz + \ldots \\). 
 


### PR DESCRIPTION
Hello,

A tiny typo being fixed in recent example Integrating piecewise affine functions (the *reason* we use YALMIP)